### PR TITLE
chore: use es modules instead of commonjs

### DIFF
--- a/.github/workflows/agency-onboarding.yml
+++ b/.github/workflows/agency-onboarding.yml
@@ -44,19 +44,19 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
+            const fs = await import('fs')
+            const path = await import('path')
 
             const templatePath = '.github/workflows/agency-onboarding/parent.md';
             const { long_name, short_name, transit_processor, website, launch_date } = context.payload.inputs;
 
             // read body from template, fill in placeholders
-            let body = fs.readFileSync(templatePath, 'utf8');
-            body = body.replace(/{{LONG_NAME}}/g, long_name)
-                       .replace(/{{SHORT_NAME}}/g, short_name)
-                       .replace(/{{TRANSIT_PROCESSOR}}/g, transit_processor)
-                       .replace(/{{WEBSITE}}/g, website || "N/A")
-                       .replace(/{{LAUNCH_DATE}}/g, launch_date || "TBD");
+            const body = fs.readFileSync(templatePath, 'utf8')
+              .replace(/{{LONG_NAME}}/g, long_name)
+              .replace(/{{SHORT_NAME}}/g, short_name)
+              .replace(/{{TRANSIT_PROCESSOR}}/g, transit_processor)
+              .replace(/{{WEBSITE}}/g, website || "N/A")
+              .replace(/{{LAUNCH_DATE}}/g, launch_date ?? "TBD");
 
             const response = await github.rest.issues.create({
               owner: context.repo.owner,
@@ -74,7 +74,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -88,7 +88,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const updateAdoptionTable = require('./.github/workflows/agency-onboarding/adoption-table.js');
+            const { updateAdoptionTable } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/adoption-table.js')
 
             draftPr = await updateAdoptionTable({
               github, context,
@@ -102,7 +102,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
+            
             const { transit_processor } = context.payload.inputs;
 
             await createChild({
@@ -117,7 +118,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -132,7 +133,7 @@ jobs:
         if: inputs.transit_processor == 'Littlepay'
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -146,7 +147,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -160,7 +161,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -174,7 +175,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -188,7 +189,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,
@@ -202,7 +203,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const createChild = require('./.github/workflows/agency-onboarding/child-issue.js');
+            const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
 
             await createChild({
               github, context, core,

--- a/.github/workflows/agency-onboarding/adoption-table.js
+++ b/.github/workflows/agency-onboarding/adoption-table.js
@@ -1,10 +1,7 @@
-const fs = require("fs");
+const fs = await import('fs')
 
-module.exports = async ({ github, context, parentIssue }) => {
-  const { long_name, launch_date, short_name } = context.payload.inputs;
-
-  // Helper function to convert "Month Year" to "MM/YYYY", or return "Planned"
-  function convertToMMYYYY(dateStr) {
+// Helper function to convert "Month Year" to "MM/YYYY", or return "Planned"
+function convertToMMYYYY(dateStr) {
     if (!dateStr || !dateStr.trim()) {
       return "Planned";
     }
@@ -36,6 +33,9 @@ module.exports = async ({ github, context, parentIssue }) => {
     // If not in expected format, return as-is (assume it's already MM/YYYY)
     return dateStr.trim();
   }
+
+export const updateAdoptionTable =  async ({ github, context, parentIssue }) => {
+  const { long_name, launch_date, short_name } = context.payload.inputs;
 
   const launchDateStr = convertToMMYYYY(launch_date);
 

--- a/.github/workflows/agency-onboarding/child-issue.js
+++ b/.github/workflows/agency-onboarding/child-issue.js
@@ -1,7 +1,7 @@
-const fs = require("fs");
-const path = require("path");
+const fs = await import('fs')
+const path = await import("path");
 
-module.exports = async ({
+export const createChild = async ({
   github,
   context,
   core,
@@ -18,10 +18,8 @@ module.exports = async ({
     `.github/workflows/agency-onboarding/${templateName}`,
   );
 
-  let body = fs.readFileSync(templatePath, "utf8");
-
-  // replace all placeholders
-  body = body
+    // replace all placeholders
+  const body = fs.readFileSync(templatePath, "utf8")
     .replace(/{{LONG_NAME}}/g, long_name)
     .replace(/{{SHORT_NAME}}/g, short_name)
     .replace(/{{TRANSIT_PROCESSOR}}/g, transit_processor)


### PR DESCRIPTION
this is a little more convoluted than it should be. ie: we have to do this
```js
const fs = await import('fs')
const { createChild } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js')
```
instead of this:
```js
import fs from "fs";
import { createChild } from '${{ github.workspace }}/.github/workflows/agency-onboarding/child-issue.js'
```

but i still think its a bit more legible and future proof.

(see https://github.com/actions/github-script/issues/168 for more info on the limitations of module imports in github-scripts.)

working on this i realized that its possible to specify the target branch when kicking off a manual github action run. see open issues and the other open PR for proof that it works.

<img width="377" height="497" alt="Screenshot 2026-02-19 at 3 55 19 PM" src="https://github.com/user-attachments/assets/4855757c-7db5-4e48-8ccf-c362834314a0" />